### PR TITLE
Move x5c into key and added required parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,12 +7,17 @@ const key = fs.readFileSync(args[0]);
 const chain = args.slice(1)
 
 const keystore = jose.JWK.createKeyStore();
-const chainvals = chain.map(file => fs.readFileSync(file, 'ascii'))
+const chainvals = chain.map(file =>
+	fs.readFileSync(file, 'ascii').split('\n').slice(1, -2).join('')
+)
 
 keystore
 	.add(key, 'pem')
 	.then(_ => {
 		const jwks = keystore.toJSON();
-		jwks.x5c = chain ? chainvals : undefined;
+		jwks.keys[0].x5c = chain ? chainvals : undefined;
+		jwks.keys[0].use = "enc";
+		jwks.keys[0].alg = "RSA-OAEP";
+		jwks.keys[0].expires_on = 2222222222;
 		console.log(JSON.stringify(jwks, null, 4));
 	});


### PR DESCRIPTION
* Moved the x509 Certificate into the key
* Added the fields for use, expires_on and alg per Chase's requirements

Adapted from this PR:
https://github.com/mhanberry/pem-to-jwk/pull/1